### PR TITLE
Fix field-feedback round 2: offline correctness, group-mode 500, admin menu, labels

### DIFF
--- a/main.py
+++ b/main.py
@@ -1009,30 +1009,35 @@ def update_all():
     candidates = Candidate.query.filter_by(group_id=current_user.id).all()
     candidates = [int(candidate.id.split("/")[1]) for candidate in candidates if candidate.status != "פרש"]
     candidates.sort()
-    counter = 0
-    output = []
     result2 = request.form.to_dict(flat=False)
+    if 'station' not in result2:
+        return redirect(url_for('add_new_group_review'))
     station = result2['station'][0]
     if station == "ODT":
-        station = station + " " + result2['odt'][0]
+        station = station + " " + result2.get('odt', [''])[0]
     if station == "אחר":
-        station = result2['odt'][0]
-    result2.pop('station')
-    result2.pop("odt")
-    datamap = [{key: value[i] for key, value in result2.items()} for i in range(len(result2['grade']))]
-    for point in datamap:
-        if int(point['grade']) != 0:
+        station = result2.get('odt', [''])[0]
+    # Only look at grade/note - the form may carry extra keys (csrf_token,
+    # request_id from the offline replay) with a different number of values.
+    grades = result2.get('grade', [])
+    notes = result2.get('note', [])
+    for i, (candidate_num, grade) in enumerate(zip(candidates, grades)):
+        try:
+            grade = int(grade)
+        except ValueError:
+            continue
+        if grade != 0:
+            note = notes[i] if i < len(notes) else ''
             new_review = Review(
                 station=station,
-                subject_id=str(current_user.id) + "/" + str(candidates[counter]),
-                grade=int(point['grade']),
-                note=point['note'],
+                subject_id=str(current_user.id) + "/" + str(candidate_num),
+                grade=grade,
+                note=note,
                 author=current_user,
-                subject=Candidate.query.filter_by(id=str(current_user.id) + "/" + str(candidates[counter])).first()
+                subject=Candidate.query.filter_by(id=str(current_user.id) + "/" + str(candidate_num)).first()
             )
             db.session.add(new_review)
             db.session.commit()
-        counter += 1
     update_avgs_nf()
     flash(f'ציוני התחנה {station} נשמרו בהצלחה!', 'success')
     return redirect(url_for('add_new_group_review'))

--- a/static/js/offline.js
+++ b/static/js/offline.js
@@ -66,16 +66,18 @@
   // clobbered by) the persistent offline strip:
   //   * offlineBar — sticky status, shown only while offline, sits above the dock
   //   * toastEl    — transient success/sync message, auto-dismisses
-  var BAR_CSS = 'position:fixed;left:0;right:0;z-index:60;transform:translateY(150%);' +
+  // pointer-events:none — nothing in the banners is interactive, so taps must
+  // always pass through to the dock/page beneath.
+  var BAR_CSS = 'position:fixed;left:0;right:0;z-index:60;pointer-events:none;transform:translateY(150%);' +
     'transition:transform .25s ease;padding:10px 14px;text-align:center;font-weight:600;' +
     'font-size:14px;color:#fff;box-shadow:0 -2px 10px rgba(0,0,0,.18)';
 
   function dockOffset() {
     // Recomputed every time we show something, so the bar always clears the
     // dock even if the dock wasn't laid out yet when the element was created.
+    // offsetHeight is already 0 when the dock is display:none.
     var dock = document.querySelector('.dock');
-    if (dock && getComputedStyle(dock).display !== 'none') return dock.offsetHeight;
-    return 0;
+    return dock ? dock.offsetHeight : 0;
   }
 
   var offlineBar, offlineBarShown = false;
@@ -99,6 +101,12 @@
     if (offlineBar) offlineBar.style.transform = 'translateY(150%)';
     offlineBarShown = false;
   }
+  // Rotation/resize can change the dock height — keep the shown bar above it.
+  function repositionOfflineBar() {
+    if (offlineBarShown && offlineBar) offlineBar.style.bottom = dockOffset() + 'px';
+  }
+  window.addEventListener('resize', repositionOfflineBar);
+  window.addEventListener('orientationchange', repositionOfflineBar);
 
   var toastEl, toastTimer;
   function ensureToast() {
@@ -264,6 +272,20 @@
       });
     });
   }
+
+  // --- online-only forms ----------------------------------------------------
+  // Any form NOT marked data-offline needs the server right now (login, batch
+  // add, report filters). Offline, block it with a clear message instead of
+  // letting the browser navigate to its native error page. Capture phase so we
+  // run before the form's own submit handlers.
+  document.addEventListener('submit', function (e) {
+    if (!offline) return;
+    var form = e.target;
+    if (!form || form.hasAttribute('data-offline')) return; // queued by bindForms
+    e.preventDefault();
+    e.stopPropagation();
+    toast('אין חיבור לרשת — פעולה זו דורשת אינטרנט');
+  }, true);
 
   // --- wiring ---------------------------------------------------------------
   if ('serviceWorker' in navigator) {

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,4 +1,4 @@
-const VERSION = 'v7';
+const VERSION = 'v8';
 const SHELL_CACHE = 'meymadion-shell-' + VERSION;
 const PAGE_CACHE = 'meymadion-pages-' + VERSION;
 
@@ -79,5 +79,13 @@ self.addEventListener('fetch', event => {
     );
     return;
   }
-  // Everything else (admin, downloads, exports): straight to network.
+
+  // Other navigations (admin, downloads, exports) are online-only and never
+  // cached — but a failure should land on our branded offline page, not the
+  // browser's native error.
+  if (req.mode === 'navigate') {
+    event.respondWith(fetch(req).catch(() => caches.match('/offline')));
+    return;
+  }
+  // Non-navigation requests (API fetches etc.): straight to network.
 });

--- a/templates/add-status.html
+++ b/templates/add-status.html
@@ -14,7 +14,7 @@
 <section class="px-4 mt-4 max-w-md mx-auto">
   <div class="card bg-base-100 shadow-sm">
     <div class="card-body p-4">
-      {{ f.render_form(form, submit_label="שמור") }}
+      {{ f.render_form(form, submit_label="שמור", offline=True) }}
     </div>
   </div>
 </section>

--- a/templates/candidate-profile.html
+++ b/templates/candidate-profile.html
@@ -31,7 +31,7 @@
   <div class="flex flex-wrap gap-1.5 mt-3">
     {% if candidate.status == "פרש" %}
       {% if candidate.withdraw_reason == "רפואי" %}
-        <span class="badge badge-error font-medium"><i class="fas fa-user-md"></i>&nbsp;הורד ע"י רופא</span>
+        <span class="badge badge-error font-medium"><i class="fas fa-user-md"></i>&nbsp;הופרש ע"י הרופא</span>
       {% else %}
         <span class="badge badge-neutral font-medium">פרש</span>
       {% endif %}

--- a/templates/counter-review.html
+++ b/templates/counter-review.html
@@ -65,9 +65,23 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {
+    const stationSelect = document.getElementById('station');
+    var currentStation = stationSelect.value;
+    // Per-station in-page cache: station -> { candidateId: {counter, note} }.
+    // Keeps this session's entries when switching stations offline.
+    var stationData = {};
+
+    function cacheRow(candidateId) {
+        if (!stationData[currentStation]) stationData[currentStation] = {};
+        stationData[currentStation][candidateId] = {
+            counter: parseInt(document.getElementById(`grade-${candidateId}`).textContent),
+            note: document.getElementById(`note-${candidateId}`).value
+        };
+    }
+
     function updateAllReviews(showMessage = false) {
         const data = {
-            station: document.getElementById('station').value,
+            station: currentStation,
             reviews: []
         };
 
@@ -119,6 +133,24 @@ document.addEventListener('DOMContentLoaded', function() {
         .catch(error => console.error('Error:', error));
     }
 
+    // ponytail: 400ms trailing debounce on +/- POSTs — every tap used to fire one,
+    // which flooded the offline outbox. "סיים מסע" and station switches flush it.
+    var debounceTimer = null;
+    function scheduleUpdate() {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(function() {
+            debounceTimer = null;
+            updateAllReviews();
+        }, 400);
+    }
+    function flushPendingUpdate() {
+        if (debounceTimer !== null) {
+            clearTimeout(debounceTimer);
+            debounceTimer = null;
+            updateAllReviews();
+        }
+    }
+
     // Handle plus/minus buttons
     document.querySelectorAll('.plus-btn, .minus-btn').forEach(button => {
         button.addEventListener('click', function() {
@@ -133,14 +165,25 @@ document.addEventListener('DOMContentLoaded', function() {
             }
 
             gradeSpan.textContent = currentCounter;
+            cacheRow(candidateId);
 
-            // Update all reviews whenever a counter changes
-            updateAllReviews();
+            // Update all reviews whenever a counter changes (debounced)
+            scheduleUpdate();
+        });
+    });
+
+    // Keep the local cache fresh on note edits (notes are still only
+    // submitted with the next counter change or "סיים מסע")
+    document.querySelectorAll('.note-input').forEach(input => {
+        input.addEventListener('change', function() {
+            cacheRow(this.id.replace('note-', ''));
         });
     });
 
     // Handle submit all button (finish march)
     document.getElementById('submitAll').addEventListener('click', function() {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
         updateAllReviews(true);  // Show success message when explicitly finishing march
     });
 
@@ -149,25 +192,45 @@ document.addEventListener('DOMContentLoaded', function() {
         fetch(`/get-station-reviews/${station}`)
             .then(response => response.json())
             .then(data => {
+                if (station !== currentStation) return; // stale response, user switched again
+                if (!stationData[station]) stationData[station] = {};
                 data.reviews.forEach(review => {
                     const gradeSpan = document.getElementById(`grade-${review.subject}`);
                     const noteInput = document.getElementById(`note-${review.subject}`);
 
                     if (gradeSpan) gradeSpan.textContent = review.counter_value || 0;
                     if (noteInput) noteInput.value = review.note || '';
+                    stationData[station][review.subject] = {
+                        counter: review.counter_value || 0,
+                        note: review.note || ''
+                    };
                 });
             })
-            .catch(error => console.error('Error:', error));
+            .catch(error => console.error('Error:', error)); // offline: keep reset/local-cache values
     }
 
-    // Handle station changes
-    const stationSelect = document.getElementById('station');
+    // Handle station changes: flush pending POST for the old station, then
+    // reset every row synchronously so a slow/failed fetch can never leave
+    // the previous station's values on screen.
     stationSelect.addEventListener('change', function() {
-        loadStationReviews(this.value);
+        flushPendingUpdate();
+        currentStation = this.value;
+        const cached = stationData[currentStation] || {};
+        document.querySelectorAll('tbody tr').forEach(row => {
+            const candidateId = row.querySelector('.plus-btn').dataset.candidate;
+            const entry = cached[candidateId];
+            document.getElementById(`grade-${candidateId}`).textContent = entry ? entry.counter : 0;
+            document.getElementById(`note-${candidateId}`).value = entry ? entry.note : '';
+        });
+        loadStationReviews(currentStation);
     });
 
-    // Load initial station data
-    loadStationReviews(stationSelect.value);
+    // Seed the cache for the initial station from the server-rendered DOM,
+    // then reconcile with the server.
+    document.querySelectorAll('tbody tr').forEach(row => {
+        cacheRow(row.querySelector('.plus-btn').dataset.candidate);
+    });
+    loadStationReviews(currentStation);
 });
 </script>
 {% include "footer.html" %}

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,5 +1,9 @@
     </main>
 
+    {# `set` inside an include doesn't escape its scope, so header.html's
+       is_admin never reaches this file — recompute it here. #}
+    {% set is_admin = current_user.is_authenticated and current_user.id == 0 %}
+
     {% if current_user.is_authenticated %}
     <!-- Bottom navigation (mobile) -->
     <div class="dock bg-base-100 border-t border-base-300 md:hidden app-dock">

--- a/templates/header.html
+++ b/templates/header.html
@@ -33,7 +33,10 @@
   <!-- Modern Hebrew font -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;500;600;700;800&family=Rubik:wght@500;600;700;800;900&display=swap" rel="stylesheet">
+  {# Loaded non-blocking: offline, a hanging fonts.googleapis.com request would
+     otherwise stall CSSOM and block every end-of-body script (frozen taps). #}
+  <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;500;600;700;800&family=Rubik:wght@500;600;700;800;900&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;500;600;700;800&family=Rubik:wght@500;600;700;800;900&display=swap" rel="stylesheet"></noscript>
   <!-- App styles (Tailwind v4 + DaisyUI, built from static/src/input.css) -->
   <link href="{{ url_for('static', filename='css/app.css') }}" rel="stylesheet">
 </head>

--- a/templates/make-post-group.html
+++ b/templates/make-post-group.html
@@ -19,7 +19,7 @@
 <section class="px-4 mt-2">
   <div class="card bg-base-100 shadow-sm">
     <div class="card-body p-4 gap-4">
-      <form method="POST" action="{{ url_for('update_all') }}" class="flex flex-col gap-4">
+      <form method="POST" action="{{ url_for('update_all') }}" data-offline class="flex flex-col gap-4">
         {{ user_form.csrf_token }}
 
         <div class="form-control w-full">

--- a/templates/make-post.html
+++ b/templates/make-post.html
@@ -21,7 +21,7 @@
 <section class="px-4 mt-2 max-w-md mx-auto">
   <div class="card bg-base-100 shadow-sm">
     <div class="card-body p-4">
-      <form method="POST" novalidate class="flex flex-col gap-3">
+      <form method="POST" novalidate data-offline class="flex flex-col gap-3">
         {{ form.hidden_tag() }}
 
         <div class="form-control w-full">

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -33,7 +33,7 @@
                 <button type="submit" class="btn btn-sm btn-outline btn-warning" onclick="return confirm('האם אתה בטוח שברצונך לסמן מועמד זה כפורש?')">פרש</button>
               </form>
               <form method="POST" data-offline class="inline" action="{{ url_for('delete_candidate', candidate_id=candidate.id.split('/')[1], reason='medical') }}">
-                <button type="submit" class="btn btn-sm btn-outline btn-error" onclick="return confirm('האם אתה בטוח שברצונך לסמן מועמד זה כפורש בעקבות החלטת רופא?')">פרש (רופא)</button>
+                <button type="submit" class="btn btn-sm btn-outline btn-error" onclick="return confirm('האם אתה בטוח שברצונך לסמן מועמד זה כפורש בעקבות החלטת רופא?')">הופרש על ידי הרופא</button>
               </form>
             {% else %}
               <form method="POST" data-offline class="inline" action="{{ url_for('return_candidate', candidate_id=candidate.id.split('**')[0].split('/')[1]) }}">
@@ -62,7 +62,7 @@
             <div class="flex-1 min-w-0 flex items-center gap-2">
               <span class="font-semibold truncate">{{ candidate.name }}</span>
               {% if candidate.withdraw_reason == "רפואי" %}
-                <span class="badge badge-error badge-sm font-medium">הורד ע"י רופא</span>
+                <span class="badge badge-error badge-sm font-medium">הופרש ע"י הרופא</span>
               {% endif %}
             </div>
             {% if candidate.status != "פרש" %}


### PR DESCRIPTION
Fixes all 9 items from the latest field-testing feedback (screenshots + 4 videos).

## Bugs fixed
- **Group mode 500 (even online):** `update_all()` crashed with an IndexError because the page redesign added a `csrf_token` field to the form. Rows are now built explicitly from `grade`/`note`, with guards for GET/empty submits, unparseable grades, and count mismatches. Verified in Docker with the exact crashing payload.
- **Offline scores leaking between מסע 1/2/3:** switching stations never reset the rows, and offline the reviews fetch failed silently, so the previous station's values stayed on screen and got queued under the wrong station. Station switches now reset synchronously, a per-station cache preserves offline entries, stale responses are ignored, and the per-tap POSTs are debounced (no more 74-item sync floods).
- **Frozen screen while offline:** the Google Fonts stylesheet hung offline and blocked every end-of-body script until timeout. It now loads non-blocking.
- **Offline submit → Safari error page:** single-mode, group-mode, and final-status forms now carry `data-offline` and queue on-device. Any other form submitted offline is blocked with a clear toast, and every failed offline navigation lands on the branded /offline page instead of the browser error.
- **Notification banners covering the bottom nav:** banners are now `pointer-events:none`, positioned reliably above the dock, and reposition on rotation. SW cache bumped to v8 so installed clients pick up the fixed assets.
- **Admin (group 0) seeing the coach menu:** `is_admin` was set in header.html but Jinja include scope meant footer.html never saw it — admins always got the coach menu (הזן ראיון etc.). It's now computed in the footer.
- **Labels:** "פרש (רופא)" → "הופרש על ידי הרופא"; badge "הורד ע\"י רופא" → "הופרש ע\"י הרופא" (panel + candidate profile).

## Verification
- Runtime smoke test inside the production Docker image (Python 3.9, temp sqlite): group-mode POST with csrf/replay fields, GET/empty-POST guards, per-station counter-review keying, field-page rendering, coach vs admin menus — all pass.
- `py_compile`, Jinja parse of all changed templates, `node --check` on offline.js/sw.js.