### PR TITLE
Fix admin data export 500 + group-mode Enter submitting the form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,4 +174,4 @@ venv/
 
 # Node / Tailwind build (the generated static/css/app.css IS committed)
 node_modules/
-.playwright-mcp/
+.playwright-mcp/multiple.xlsx

--- a/main.py
+++ b/main.py
@@ -2118,8 +2118,14 @@ def downloadb():
     engine = sqlalchemy.create_engine(app.config['SQLALCHEMY_DATABASE_URI'])
     df1 = pd.read_sql(db.session.query(Candidate).statement, db.session.bind)
     df1 = df1[df1["status"] != "פרש"]
-    df1.drop(['status'], axis=1, inplace=True)
-    df1.columns = ["מספר מגובש", "מספר קבוצה", "שם", "סטטוס סיכום", "הערת סיכום", "שם מראיין", "ציון ראיון", "סיכום ראיון", "בעיות תש", "בעיות רפואיות"]
+    # Rename by name and select explicitly, so adding columns to Candidate
+    # (e.g. withdraw_reason) can't shift the mapping and 500 the export.
+    export_columns = {"id": "מספר מגובש", "group_id": "מספר קבוצה", "name": "שם",
+                      "final_status": "סטטוס סיכום", "final_note": "הערת סיכום",
+                      "interviewer": "שם מראיין", "interview_grade": "ציון ראיון",
+                      "interview_note": "סיכום ראיון", "tash_prob": "בעיות תש",
+                      "medical_prob": "בעיות רפואיות"}
+    df1 = df1.rename(columns=export_columns)[list(export_columns.values())]
     df1["מתאם(קבוצת ליבה)"] = pd.Series()
     df1["מגבש"] = pd.Series()
     df1.index = df1['מספר מגובש']

--- a/templates/make-post-group.html
+++ b/templates/make-post-group.html
@@ -61,6 +61,17 @@
 
 <script>
   document.addEventListener('DOMContentLoaded', function () {
+    // Enter inside a text field must NOT submit the whole batch form (mobile
+    // keyboards make this an easy accident that wipes unentered grades).
+    // Blur instead, which closes the on-screen keyboard. Submitting stays
+    // explicit via the הזן ציונים button.
+    document.querySelector('form[data-offline]').addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' && e.target.matches('input, select')) {
+        e.preventDefault();
+        e.target.blur();
+      }
+    });
+
     var stationField = document.getElementById('station');
     var additionalField = document.getElementById('additionalField');
     if (!stationField) return;

--- a/tests/test_download_sheet.py
+++ b/tests/test_download_sheet.py
@@ -1,0 +1,45 @@
+"""Smoke test: /download-sheet/ must return 200 + a real xlsx.
+
+Regression: adding a column to Candidate (withdraw_reason) shifted the
+positional column rename in downloadb() and 500'd the admin data export.
+
+Run inside the project Docker image (local python can't install the pinned deps):
+    docker build -t gibushun-smoke .
+    docker run --rm -v "$PWD:/app" -w /app -e PYTHONPATH=/app gibushun-smoke \
+        python tests/test_download_sheet.py
+"""
+import io
+import os
+import zipfile
+
+# Force a throwaway DB before importing main — this test drops all tables.
+os.environ["DATABASE_URL"] = "sqlite:////tmp/test_download_sheet.db"
+
+from main import app, db, User, Candidate, Review  # noqa: E402
+
+with app.app_context():
+    db.drop_all()
+    db.create_all()
+    admin = User(id=0, name="admin", password="x", mitam_num=0,
+                 sprint_num=0, crawl_num=0, alonka_num=0)
+    group = User(id=1, name="group1", password="x", mitam_num=7,
+                 sprint_num=0, crawl_num=0, alonka_num=0)
+    db.session.add_all([admin, group])
+    active = Candidate(id="1/1", group_id=1, name="a", status="פעיל")
+    withdrawn = Candidate(id="1/2", group_id=1, name="b", status="פרש",
+                          withdraw_reason="רפואי")
+    db.session.add_all([active, withdrawn])
+    db.session.add(Review(author_id=1, station="בוחן", subject_id="1/1", grade=3.0))
+    db.session.commit()
+
+client = app.test_client()
+with client.session_transaction() as sess:
+    sess["_user_id"] = "0"
+
+resp = client.get("/download-sheet/")
+assert resp.status_code == 200, f"expected 200, got {resp.status_code}"
+data = resp.get_data()
+assert data[:2] == b"PK", "response is not an xlsx (zip) file"
+zf = zipfile.ZipFile(io.BytesIO(data))
+assert any(n.startswith("xl/") for n in zf.namelist())
+print("OK: /download-sheet/ returned 200 with a valid xlsx,", len(data), "bytes")


### PR DESCRIPTION
Fixes two field-reported bugs (with screen recordings):

## 1. הורד נתונים (admin data export) → 500
Since `withdraw_reason` was added to `Candidate` (71b55cf), `/download-sheet/` crashed: the export renamed the DataFrame columns **positionally** with a hard-coded 10-name list against what is now 11 columns → `ValueError` → 500.

**Fix:** rename by column name and select the export columns explicitly, so adding columns to `Candidate` can never shift the mapping again.

**Validated:** regression test `tests/test_download_sheet.py` (run in the project Docker image) — 500 on master, 200 + valid xlsx with this fix.

## 2. מצב קבוצתי: Enter במקלדת שולח את הטופס
In group-mode grade entry, pressing Enter (the blue key on the mobile keyboard) inside a note field fired the form's implicit submission — submitting a mostly-empty batch and wiping everyone's not-yet-entered grades.

**Fix:** Enter inside the form's inputs/selects now just blurs the field (which closes the on-screen keyboard). Submitting is only via the explicit הזן ציונים button.

**Validated:** Playwright against the running app — Enter in a note field no longer navigates/submits and the typed note is preserved; clicking the button still submits and writes the review rows.